### PR TITLE
Fix install_requires in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pandas>=0.25.3
-requests>= 2.23.0
+requests>=2.23.0
 marshmallow-dataclass==7.5.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with Path("requirements.txt").open() as requirements_txt:
 
 setup(
     name="python-adjust",
-    version="1.0.1",
+    version="1.0.2",
     packages=["adjustapi"],
     description="Adjust.com REST API python implementation",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,41 @@
 #!/usr/bin/env python
 from pkg_resources import parse_requirements
 from setuptools import setup
+from pathlib import Path
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-install_reqs = list(map(str, parse_requirements('requirements.txt')))
+
+with Path("requirements.txt").open() as requirements_txt:
+    install_requires = [
+        str(requirement) for requirement in parse_requirements(requirements_txt)
+    ]
 
 setup(
-    name='python-adjust',
-    version='1.0.1',
-    packages=['adjustapi'],
-    description='Adjust.com REST API python implementation',
+    name="python-adjust",
+    version="1.0.1",
+    packages=["adjustapi"],
+    description="Adjust.com REST API python implementation",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/sann05/python-adjust',
-    author='Aliaksandr Sheliutsin',
-    license='MIT',
-    author_email='',
-    install_requires=install_reqs,
-    keywords='adjust mobile measurement kpi api',
+    url="https://github.com/sann05/python-adjust",
+    author="Aliaksandr Sheliutsin",
+    license="MIT",
+    author_email="",
+    install_requires=install_requires,
+    keywords="adjust mobile measurement kpi api",
     classifiers=[
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires='>=3.5',
+    python_requires=">=3.5",
 )


### PR DESCRIPTION
HI @sann05, tried to install your package but ran into this error:

```sh
> pip install python-adjust
Obtaining file:///Users/louis.guitton/workspace/python-adjust
ERROR: Could not find a version that satisfies the requirement requirements.txt (from python-adjust==1.0.1) (from versions: none)
ERROR: No matching distribution found for requirements.txt (from python-adjust==1.0.1)
WARNING: You are using pip version 20.2.3; however, version 21.1.3 is available.
You should consider upgrading via the '/Users/louis.guitton/workspace/python-adjust/venv/bin/python -m pip install --upgrade pip' command.
```

You can fix that by opening the textfile before parsing it.