### PR TITLE
Fix missing is_ctv in model.App

### DIFF
--- a/adjustapi/model.py
+++ b/adjustapi/model.py
@@ -74,6 +74,7 @@ class App:
     platforms: dict
     permissions: Permissions
     currency: Currency
+    is_ctv: Optional[bool]
 
 
 @dataclass


### PR DESCRIPTION
Added is_ctv: bool as Optional to model.App. This field is a new return from Adjust API.